### PR TITLE
Fix missing space in PRINT-OBJECT for TYPE-ERROR.

### DIFF
--- a/src/code/condition.lisp
+++ b/src/code/condition.lisp
@@ -1235,7 +1235,7 @@ the values returned by the form as a list. No associated restarts."))
 (defvar *muffled-warnings* 'uninteresting-redefinition
   #!+sb-doc
   "A type that ought to specify a subtype of WARNING.  Whenever a
-warning is signaled, if the warning if of this type and is not
+warning is signaled, if the warning is of this type and is not
 handled by any other handler, it will be muffled.")
 
 ;;; Various STYLE-WARNING signaled in the system.

--- a/src/code/condition.lisp
+++ b/src/code/condition.lisp
@@ -533,7 +533,7 @@
           (if (and type datum)
               (print-unreadable-object (condition stream :type t)
                 (format stream "~@<expected-type: ~
-                                 ~/sb-impl:print-type-specifier/~_datum: ~
+                                 ~/sb-impl:print-type-specifier/ ~_datum: ~
                                  ~A~:@>"
                         type datum))
               (call-next-method))))


### PR DESCRIPTION
Before this change, the output looked like

```
#<TYPE-ERROR expected-type: "STRING"datum: 97>
```
